### PR TITLE
更新各种链接

### DIFF
--- a/docs/footer.md
+++ b/docs/footer.md
@@ -1,3 +1,3 @@
 <br>
 
-<span style="font-size:0.9em">文档 v2.0.0 由 [MaxXing](https://github.com/MaxXSoft) 撰写, 采用 [CC BY-NC-SA 4.0 协议](http://creativecommons.org/licenses/by-nc-sa/4.0/)发布.<span>
+<span style="font-size:0.9em">文档 v2.0.0 由 [MaxXing](https://github.com/MaxXSoft) 撰写, 采用 [CC BY-NC-SA 4.0 协议](https://creativecommons.org/licenses/by-nc-sa/4.0/)发布.<span>

--- a/docs/lv9p-reincarnation/ssa-form.md
+++ b/docs/lv9p-reincarnation/ssa-form.md
@@ -179,7 +179,7 @@ end:
   ret %a_3
 ```
 
-基本块参数就像函数参数一样, 相信对于你来说, 这并不难理解. 同时, 在 $\phi$ 函数和基本块参数这两种风格之间转换, 也是比较 trivial 的, 此处不再赘述. 至于为什么采用这样的设计, 你可以参考 MaxXing 写的某篇 blog: [SSA 形式的设计取舍: Phi 函数的新形式?](http://blog.maxxsoft.net/index.php/archives/143/).
+基本块参数就像函数参数一样, 相信对于你来说, 这并不难理解. 同时, 在 $\phi$ 函数和基本块参数这两种风格之间转换, 也是比较 trivial 的, 此处不再赘述. 至于为什么采用这样的设计, 你可以参考 MaxXing 写的某篇 blog: [SSA 形式的设计取舍: Phi 函数的新形式?](https://blog.maxxsoft.net/index.php/archives/143/).
 
 ## 进入和退出 SSA 形式
 

--- a/docs/misc-app-ref/environment.md
+++ b/docs/misc-app-ref/environment.md
@@ -260,7 +260,7 @@ autotest -t 测试用例目录 编译器项目目录
 
 如果你不满足于实验环境内附带的测试用例, 你可以自己编写一些测试用例来测试自己的编译器. 当然, 你可以使用一些现成的第三方的测试用例:
 
-* [**compiler2021**](https://gitlab.eduxiji.net/nscscc/compiler2021/-/tree/master/%E5%85%AC%E5%BC%80%E7%94%A8%E4%BE%8B%E4%B8%8E%E8%BF%90%E8%A1%8C%E6%97%B6%E5%BA%93): 编译系统设计赛官方测试用例.
+* [**compiler2021**](https://gitlab.eduxiji.net/csc1/nscscc/compiler2021/-/tree/master/%E5%85%AC%E5%BC%80%E7%94%A8%E4%BE%8B%E4%B8%8E%E8%BF%90%E8%A1%8C%E6%97%B6%E5%BA%93): 编译系统设计赛官方测试用例.
 * [**minic-test-cases-2021s**](https://github.com/pku-minic/minic-test-cases-2021s): 北大编译实践课程 2021 年春季学期使用的测试用例.
 * [**minic-test-cases-2021f**](https://github.com/pku-minic/minic-test-cases-2021f): 北大编译实践课程 2021 年秋季学期使用的测试用例.
 * [**segviol/indigo**](https://github.com/segviol/indigo/tree/develop/test_codes/upload): 2020 年第一届编译系统设计赛北航参赛队开发的 indigo 编译器的内部测试用例.

--- a/docs/misc-app-ref/koopa.md
+++ b/docs/misc-app-ref/koopa.md
@@ -365,7 +365,7 @@ BlockParamList ::= "(" SYMBOL ":" Type {"," SYMBOL ":" Type} ")";
 
 Koopa 支持 SSA 形式, 但这并非是必选内容. 为了实现更多更强大的优化, 你可以选择将 Koopa 转换到 SSA 形式. 但我觉得这部分内容不应该放在本科编译原理的课程实践中, 也许可以针对本科生再开一门和编译优化相关的课程.
 
-我们并没有选择让 SSA 的 Koopa 采用 Phi 函数的形式, 虽然我们之前确实这么做了, 但权衡之下, 我们决定采用另一种等价的形式: 基本块参数 (basic block arguments). 相比传统的 Phi 函数, 这种形式在实现上要简单得多, 且在不削弱表达能力的情况下, 可以更好的分离数据流和控制流. 关于 SSA 形式设计的讨论, 请参考 MaxXing 的[这篇博文](http://blog.maxxsoft.net/index.php/archives/143/).
+我们并没有选择让 SSA 的 Koopa 采用 Phi 函数的形式, 虽然我们之前确实这么做了, 但权衡之下, 我们决定采用另一种等价的形式: 基本块参数 (basic block arguments). 相比传统的 Phi 函数, 这种形式在实现上要简单得多, 且在不削弱表达能力的情况下, 可以更好的分离数据流和控制流. 关于 SSA 形式设计的讨论, 请参考 MaxXing 的[这篇博文](https://blog.maxxsoft.net/index.php/archives/143/).
 
 在该形式下, 原先的 Phi 语义使用基本块参数进行表示. 在进入带参数基本块时, 前驱的基本块的最后一条转移指令中必须传递基本块的实际参数. 基本块中的指令可以通过使用形式参数的方式来使用这些传入的值.
 
@@ -410,7 +410,7 @@ AnnoPair ::= AnnoName [":" AnnoValue];
 
 注解由若干个 `AnnoPair` 构成, 中间以分号分隔, 也可以以分号结尾. `AnnoPair` 包含注解的名称和注解的值, 有些注解只有名称而没有值.
 
-`AnnoName` 实际上是一个字符串, 其中不允许出现任何空白符或其他控制字符. `AnnoName` 的命名格式并无特殊规定, 你愿意的话甚至可以用中文或其他 Unicode 字符来表示, 但建议使用 [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Special_case_styles).
+`AnnoName` 实际上是一个字符串, 其中不允许出现任何空白符或其他控制字符. `AnnoName` 的命名格式并无特殊规定, 你愿意的话甚至可以用中文或其他 Unicode 字符来表示, 但建议使用 [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Use_within_programming_languages).
 
 `AnnoValue` 实际上也是一个字符串. 默认情况下, 字符串从 `AnnoName` 后的冒号处开始, 到分号处或注解结束处结束, 首尾空白符会被忽略.
 

--- a/docs/misc-app-ref/references.md
+++ b/docs/misc-app-ref/references.md
@@ -3,15 +3,15 @@
 北京大学编译实践课程在线文档参考了如下教程文档:
 
 * [清华大学 MiniDecaf 编译实验](https://decaf-lang.github.io/minidecaf-tutorial/).
-* [北京航空航天大学 miniSysY 编译实验](https://buaa-se-compiling.github.io/miniSysY-tutorial/).
+* [北京航空航天大学 miniSysY 编译实验](https://no-sf-work.github.io/miniSysY-tutorial/).
 * [南京大学计算机系统基础课程实验](https://nju-projectn.github.io/ics-pa-gitbook/ics2021/index.html).
 
 感谢这些文档的编写者/维护者们的辛苦付出! 这些都是十分优秀的编译/计算机系统类教程, MaxXing 十分推荐大家一起学习.
 
 此外, 在线文档还参考了其他文档:
 
-* [SysY 语言定义](https://gitlab.eduxiji.net/nscscc/compiler2021/-/blob/master/SysY%E8%AF%AD%E8%A8%80%E5%AE%9A%E4%B9%89.pdf).
-* [SysY 运行时库](https://gitlab.eduxiji.net/nscscc/compiler2021/-/blob/master/SysY%E8%BF%90%E8%A1%8C%E6%97%B6%E5%BA%93.pdf).
+* [SysY 语言定义](https://gitlab.eduxiji.net/csc1/nscscc/compiler2021/-/blob/master/SysY%E8%AF%AD%E8%A8%80%E5%AE%9A%E4%B9%89.pdf).
+* [SysY 运行时库](https://gitlab.eduxiji.net/csc1/nscscc/compiler2021/-/blob/master/SysY%E8%BF%90%E8%A1%8C%E6%97%B6%E5%BA%93.pdf).
 * [LLVM documentation](https://llvm.org/docs/).
 * [Cranelift IR Reference](https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/docs/ir.md).
-* [RISC-V Specifications](https://riscv.org/technical/specifications/).
+* [RISC-V Specifications](https://docs.riscv.org/reference/home/index.html).

--- a/docs/misc-app-ref/sysy-runtime.md
+++ b/docs/misc-app-ref/sysy-runtime.md
@@ -1,6 +1,6 @@
 # SysY 运行时库
 
-?> SysY 官方的运行时库规范见[这里](https://gitlab.eduxiji.net/nscscc/compiler2021/-/blob/master/SysY%E8%BF%90%E8%A1%8C%E6%97%B6%E5%BA%93.pdf).
+?> SysY 官方的运行时库规范见[这里](https://gitlab.eduxiji.net/csc1/nscscc/compiler2021/-/blob/master/SysY%E8%BF%90%E8%A1%8C%E6%97%B6%E5%BA%93.pdf).
 <br><br>
 编译实践课所使用的 SysY 运行时库和官方定义略有不同: 实践课的 `getch` 定义了遇到 `EOF` 时的行为, 同时计时函数的定义比官方定义更加简单.
 

--- a/docs/misc-app-ref/sysy-spec.md
+++ b/docs/misc-app-ref/sysy-spec.md
@@ -1,6 +1,6 @@
 # SysY 语言规范
 
-?> SysY 官方的语言定义见[这里](https://gitlab.eduxiji.net/nscscc/compiler2021/-/blob/master/SysY%E8%AF%AD%E8%A8%80%E5%AE%9A%E4%B9%89.pdf).
+?> SysY 官方的语言定义见[这里](https://gitlab.eduxiji.net/csc1/nscscc/compiler2021/-/blob/master/SysY%E8%AF%AD%E8%A8%80%E5%AE%9A%E4%B9%89.pdf).
 <br><br>
 编译实践课所使用的 SysY 语言和官方定义略有不同: 实践课的 SysY 向下兼容官方定义.
 
@@ -98,7 +98,7 @@ identifier ::= identifier-nondigit
 
 其中, `identifier-nondigit` 为下划线, 小写英文字母或大写英文字母; `digit` 为数字 0 到 9.
 
-关于其他信息, 请参考 [ISO/IEC 9899](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) 第 51 页关于标识符的定义.
+关于其他信息, 请参考 [ISO/IEC 9899](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) 第 51 页关于标识符的定义.
 
 对于同名**标识符**, SysY 中有以下约定:
 
@@ -127,7 +127,7 @@ hexadecimal-prefix  ::= "0x" | "0X";
 
 数值常量的范围为 $[0, 2^{31} - 1]$, 不包含负号.
 
-关于其他信息, 请参考 [ISO/IEC 9899](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) 第 54 页关于整数型常量的定义, 在此基础上忽略所有后缀.
+关于其他信息, 请参考 [ISO/IEC 9899](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) 第 54 页关于整数型常量的定义, 在此基础上忽略所有后缀.
 
 ### 注释
 
@@ -136,7 +136,7 @@ SysY 语言中注释的规范与 C 语言一致, 如下:
 * 单行注释: 以序列 `//` 开始, 直到换行符结束, 不包括换行符.
 * 多行注释: 以序列 `/*` 开始, 直到第一次出现 `*/` 时结束, 包括结束处 `*/`.
 
-关于其他信息, 请参考 [ISO/IEC 9899](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) 第 66 页关于注释的定义.
+关于其他信息, 请参考 [ISO/IEC 9899](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) 第 66 页关于注释的定义.
 
 ## 语义约束
 


### PR DESCRIPTION
大多是跟踪重定向。

最让我搞不懂的是miniSysY-tutorial仓库从BUAA-SE-Compiling组织迁移到了一个缩写为NSFW的组织下，没有在原网站留下重定向，新仓库也没有给出新链接，我也没有找到只迁移了原组织下某几个仓库却没有迁移其他仓库的原因。

<img width="100" height="100" alt="BUAA-SE-Compiling" src="https://github.com/user-attachments/assets/4457dac4-631d-4fe9-9bb9-9cd035f1c2fe" />
